### PR TITLE
Show post update author

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          fetch-depth: 0
           submodules: recursive
 
       - name: Setup Ruby

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -25,6 +25,10 @@ tail_includes:
     <span>
       {{ site.data.locales[lang].post.updated }}
       {% include datetime.html date=page.last_modified_at tooltip=true %}
+      {% if page.last_modified_by %}
+        {{ site.data.locales[lang].post.written_by | downcase }}
+        <em>{{ page.last_modified_by }}</em>
+      {% endif %}
     </span>
     {% endif %}
 

--- a/_plugins/posts-lastmod-hook.rb
+++ b/_plugins/posts-lastmod-hook.rb
@@ -8,7 +8,9 @@ Jekyll::Hooks.register :posts, :post_init do |post|
 
   if commit_num.to_i > 1
     lastmod_date = `git log -1 --pretty="%ad" --date=iso "#{ post.path }"`
-    post.data['last_modified_at'] = lastmod_date
+    lastmod_author = `git log -1 --pretty="%an" "#{ post.path }"`
+    post.data['last_modified_at'] = lastmod_date.strip
+    post.data['last_modified_by'] = lastmod_author.strip
   end
 
 end


### PR DESCRIPTION
## Summary
- add `last_modified_by` metadata from the latest Git author for each updated post
- display the update author next to the existing updated date in the post header
- fetch full Git history in the Pages workflow so update metadata is available during deployment

## Verification
- `bundle exec jekyll build`
- checked generated HTML includes `Updated ... by ...` in post metadata