### PR TITLE
Tidy git-to-hell post caption spacing

### DIFF
--- a/_posts/2019-06-21-go_to_git-to-hell_for_beginners.md
+++ b/_posts/2019-06-21-go_to_git-to-hell_for_beginners.md
@@ -8,4 +8,5 @@ tags: [git, gitHub, pages]
 [**🔥git-to-hell🔥지옥으로 가는 git🌟**](https://abarthdew.github.io/git-to-hell/){:target="_blank"}
 
 ![git-to-hell]({{ '/assets/img/2022/git-to-hell.png' | relative_url }})
+
 _git-to-hell_


### PR DESCRIPTION
## Summary
- add a blank line between the git-to-hell post image and caption for clearer Markdown rendering

## Verification
- `bundle exec jekyll build`

## Test note
- After this PR is merged, the post header should show the latest updated metadata for this single post.