### PR TITLE
Use post filenames for published dates

### DIFF
--- a/_posts/2019-06-21-go_to_git-to-hell_for_beginners.md
+++ b/_posts/2019-06-21-go_to_git-to-hell_for_beginners.md
@@ -1,6 +1,5 @@
 ---
 title: go to git-to-hell for beginners
-date: 2019-06-21
 categories: [git, gitHub]
 tags: [git, gitHub, pages]
 ---

--- a/_posts/2021-03-15-spring_reactive_camp1.md
+++ b/_posts/2021-03-15-spring_reactive_camp1.md
@@ -1,6 +1,5 @@
 ---
 title: 1-1. Spring Reactive - Process, Thread, Reactive
-date: 2021-03-15
 categories: [Back, Spring]
 tags: [Back, Spring]
 ---

--- a/_posts/2021-03-15-spring_reactive_camp2.md
+++ b/_posts/2021-03-15-spring_reactive_camp2.md
@@ -1,6 +1,5 @@
 ---
 title: 1-2. Spring Reactive - Async, Spring
-date: 2021-03-15
 categories: [Back, Spring]
 tags: [Back, Spring]
 ---

--- a/_posts/2021-03-15-spring_reactive_camp3.md
+++ b/_posts/2021-03-15-spring_reactive_camp3.md
@@ -1,6 +1,5 @@
 ---
 title: 1-3. Spring Reactive - Spring WebFlux
-date: 2021-03-15
 categories: [Back, Spring]
 tags: [Back, Spring]
 ---

--- a/_posts/2021-03-15-spring_reactive_camp4.md
+++ b/_posts/2021-03-15-spring_reactive_camp4.md
@@ -1,6 +1,5 @@
 ---
 title: 2-1. Spring Reactive - Reactive Spring
-date: 2021-03-15
 categories: [Back, Spring]
 tags: [Back, Spring]
 ---

--- a/_posts/2021-03-16-method_reference.md
+++ b/_posts/2021-03-16-method_reference.md
@@ -1,6 +1,5 @@
 ---
 title: JAVA Method Reference
-date: 2021-03-16
 categories: [Back, Java]
 tags: [Back, Java]
 ---

--- a/_posts/2021-08-25-git_for_advanced.md
+++ b/_posts/2021-08-25-git_for_advanced.md
@@ -1,6 +1,5 @@
 ---
 title: git for Advanced
-date: 2021-08-25
 categories: [git, gitHub]
 tags: [git, gitHub]
 ---

--- a/_posts/2021-09-11-linux_with_centos.md
+++ b/_posts/2021-09-11-linux_with_centos.md
@@ -1,6 +1,5 @@
 ---
 title: Linux with CentOS
-date: 2021-09-11
 categories: [Linux, CentOS]
 tags: [Linux, CentOS]
 ---

--- a/_posts/2021-12-06-vue_lesson.md
+++ b/_posts/2021-12-06-vue_lesson.md
@@ -1,6 +1,5 @@
 ---
 title: Vue Lesson
-date: 2021-12-06
 categories: [Front, Vue]
 tags: [Front, Vue]
 ---

--- a/_posts/2021-12-06-vue_master.md
+++ b/_posts/2021-12-06-vue_master.md
@@ -1,6 +1,5 @@
 ---
 title: Vue Master
-date: 2021-12-06
 categories: [Front, Vue]
 tags: [Front, Vue]
 ---

--- a/_posts/2022-04-01-jsp_with_eclipse.md
+++ b/_posts/2022-04-01-jsp_with_eclipse.md
@@ -1,6 +1,5 @@
 ---
 title: 0. JSP with Eclipse - List
-date: 2022-04-01
 categories: [Back, JSP]
 tags: [Back, JSP]
 ---

--- a/_posts/2022-04-01-jsp_with_eclipse1.md
+++ b/_posts/2022-04-01-jsp_with_eclipse1.md
@@ -1,6 +1,5 @@
 ---
 title: 1. JSP with Eclipse
-date: 2022-04-01
 categories: [Back, JSP]
 tags: [Back, JSP]
 ---

--- a/_posts/2022-04-01-jsp_with_eclipse2.md
+++ b/_posts/2022-04-01-jsp_with_eclipse2.md
@@ -1,6 +1,5 @@
 ---
 title: 2. JSP with Eclipse
-date: 2022-04-01
 categories: [Back, JSP]
 tags: [Back, JSP]
 ---

--- a/_posts/2022-04-01-jsp_with_eclipse3.md
+++ b/_posts/2022-04-01-jsp_with_eclipse3.md
@@ -1,6 +1,5 @@
 ---
 title: 3. JSP with Eclipse
-date: 2022-04-01
 categories: [Back, JSP]
 tags: [Back, JSP]
 ---

--- a/_posts/2022-04-08-select_all_from_postgresql1.md
+++ b/_posts/2022-04-08-select_all_from_postgresql1.md
@@ -1,6 +1,5 @@
 ---
 title: SELECT A.* FROM PostgreSQL A;
-date: 2022-04-08
 categories: [DB, RDBMS]
 tags: [DB, PostgreSQL]
 ---

--- a/_posts/2022-04-08-select_all_from_postgresql2.md
+++ b/_posts/2022-04-08-select_all_from_postgresql2.md
@@ -1,6 +1,5 @@
 ---
 title: SELECT B.* FROM PostgreSQL B;
-date: 2022-04-08
 categories: [DB, RDBMS]
 tags: [DB, PostgreSQL]
 ---

--- a/_posts/2022-04-10-this_is_java.md
+++ b/_posts/2022-04-10-this_is_java.md
@@ -1,6 +1,5 @@
 ---
 title: 0. This is Java - List
-date: 2022-04-10
 categories: [Back, Java]
 tags: [Back, Java]
 ---

--- a/_posts/2022-04-11-this_is_java1.md
+++ b/_posts/2022-04-11-this_is_java1.md
@@ -1,6 +1,5 @@
 ---
 title: 1. settings, concept, remark
-date: 2022-04-11
 categories: [Back, Java]
 tags: [Back, Java]
 ---

--- a/_posts/2022-04-12-this_is_java2.md
+++ b/_posts/2022-04-12-this_is_java2.md
@@ -1,6 +1,5 @@
 ---
 title: 2. data type basic
-date: 2022-04-12
 categories: [Back, Java]
 tags: [Back, Java]
 ---

--- a/_posts/2022-04-13-this_is_java3.md
+++ b/_posts/2022-04-13-this_is_java3.md
@@ -1,6 +1,5 @@
 ---
 title: 3. operator
-date: 2022-04-13
 categories: [Back, Java]
 tags: [Back, Java]
 ---

--- a/_posts/2022-04-14-this_is_java4.md
+++ b/_posts/2022-04-14-this_is_java4.md
@@ -1,6 +1,5 @@
 ---
 title: 4. condition statement
-date: 2022-04-14
 categories: [Back, Java]
 tags: [Back, Java]
 ---

--- a/_posts/2022-04-15-this_is_java5.md
+++ b/_posts/2022-04-15-this_is_java5.md
@@ -1,6 +1,5 @@
 ---
 title: 5. data type advance, memory area, operator for reference variable, NullPointException, String type, Array Type
-date: 2022-04-15
 categories: [Back, Java]
 tags: [Back, Java]
 ---

--- a/_posts/2022-04-16-this_is_java6.md
+++ b/_posts/2022-04-16-this_is_java6.md
@@ -1,6 +1,5 @@
 ---
 title: 6. Object, Class, field, constructor, method, this, static, final, package, access modifier, getter/setter, annotation
-date: 2022-04-16
 categories: [Back, Java]
 tags: [Back, Java]
 ---

--- a/_posts/2022-04-17-this_is_java7.md
+++ b/_posts/2022-04-17-this_is_java7.md
@@ -1,6 +1,5 @@
 ---
 title: 7. inheritance, polymorphism, Abstract Class
-date: 2022-04-17
 categories: [Back, Java]
 tags: [Back, Java]
 ---

--- a/_posts/2022-04-18-this_is_java8.md
+++ b/_posts/2022-04-18-this_is_java8.md
@@ -1,6 +1,5 @@
 ---
 title: 8. Interface, polymorphism
-date: 2022-04-18
 categories: [Back, Java]
 tags: [Back, Java]
 ---

--- a/_posts/2022-04-19-this_is_java9.md
+++ b/_posts/2022-04-19-this_is_java9.md
@@ -1,6 +1,5 @@
 ---
 title: 9. Nested Class/Interface, Anonymous Object
-date: 2022-04-19
 categories: [Back, Java]
 tags: [Back, Java]
 ---

--- a/_posts/2022-04-20-this_is_java10.md
+++ b/_posts/2022-04-20-this_is_java10.md
@@ -1,6 +1,5 @@
 ---
 title: 10. Exception
-date: 2022-04-20
 categories: [Back, Java]
 tags: [Back, Java]
 ---

--- a/_posts/2022-04-21-this_is_java11.md
+++ b/_posts/2022-04-21-this_is_java11.md
@@ -1,6 +1,5 @@
 ---
 title: 11. java docs, Object(s), System, Class, String, regex, Arrays, Wrapper, Math, Random, Date, Calendar, Format, java.time package
-date: 2022-04-21
 categories: [Back, Java]
 tags: [Back, Java]
 ---

--- a/_posts/2022-04-22-this_is_java12.md
+++ b/_posts/2022-04-22-this_is_java12.md
@@ -1,6 +1,5 @@
 ---
 title: 12. Thread
-date: 2022-04-22
 categories: [Back, Java]
 tags: [Back, Java]
 ---

--- a/_posts/2022-04-23-this_is_java13.md
+++ b/_posts/2022-04-23-this_is_java13.md
@@ -1,6 +1,5 @@
 ---
 title: 13. Generic
-date: 2022-04-23
 categories: [Back, Java]
 tags: [Back, Java]
 ---

--- a/_posts/2022-04-24-this_is_java14.md
+++ b/_posts/2022-04-24-this_is_java14.md
@@ -1,6 +1,5 @@
 ---
 title: 14. Lambda, Target, Functional Interface, Class member, local variable, API interface, method reference
-date: 2022-04-24
 categories: [Back, Java]
 tags: [Back, Java]
 ---

--- a/_posts/2022-04-25-this_is_java15.md
+++ b/_posts/2022-04-25-this_is_java15.md
@@ -1,6 +1,5 @@
 ---
 title: 15. Collections - List, Set, Map, search, LIFO/FIFO
-date: 2022-04-25
 categories: [Back, Java]
 tags: [Back, Java]
 ---

--- a/_posts/2022-04-26-this_is_java16.md
+++ b/_posts/2022-04-26-this_is_java16.md
@@ -1,6 +1,5 @@
 ---
 title: 16. Stream, parallel processing
-date: 2022-04-26
 categories: [Back, Java]
 tags: [Back, Java]
 ---

--- a/_posts/2022-04-27-how_to_make_github.io_blog.md
+++ b/_posts/2022-04-27-how_to_make_github.io_blog.md
@@ -1,6 +1,5 @@
 ---
 title: How to make github.io Blog
-date: 2022-04-27
 categories: [git, pages]
 tags: [git, pages]
 ---

--- a/_posts/2022-05-09-composition_api_and_just_component_composition_in_vue.md
+++ b/_posts/2022-05-09-composition_api_and_just_component_composition_in_vue.md
@@ -1,6 +1,5 @@
 ---
 title: Composition Api and just Component composition in Vue
-date: 2023-05-09
 categories: [Front, Vue]
 tags: [Front, Vue]
 ---

--- a/_posts/2022-05-09-what_is_different_between_npm_and_yarn.md
+++ b/_posts/2022-05-09-what_is_different_between_npm_and_yarn.md
@@ -1,6 +1,5 @@
 ---
 title: What is different between NPM and YARN?
-date: 2023-05-09
 categories: [Front, Vue]
 tags: [Front, Vue]
 ---

--- a/_posts/2022-05-09-what_is_different_between_spring_core_and_spring_mvc.md
+++ b/_posts/2022-05-09-what_is_different_between_spring_core_and_spring_mvc.md
@@ -1,6 +1,5 @@
 ---
 title: What is different between Spring Core and Spring MVC?
-date: 2023-05-09
 categories: [Back, Spring]
 tags: [Back, Spring]
 ---

--- a/_posts/2022-05-13-what_is_different_between_vue2_and_vue3.md
+++ b/_posts/2022-05-13-what_is_different_between_vue2_and_vue3.md
@@ -1,6 +1,5 @@
 ---
 title: What is different between Vue2 and Vue3?
-date: 2023-05-13
 categories: [Front, Vue]
 tags: [Front, Vue]
 ---

--- a/_posts/2023-06-29-gpt_prompt_for_highcharts.md
+++ b/_posts/2023-06-29-gpt_prompt_for_highcharts.md
@@ -1,6 +1,5 @@
 ---
 title: GPT prompt for Highcharts
-date: 2023-06-29
 categories: [AI, Gpt]
 tags: [AI, Gpt, pages]
 math: true

--- a/_posts/2026-02-15-front_quick_briefing.md
+++ b/_posts/2026-02-15-front_quick_briefing.md
@@ -1,6 +1,5 @@
 ---
 title: 프론트 퀵 브리핑
-date: 2026-02-15
 categories: [Front, JS]
 tags: [Front, JS]
 ---

--- a/_posts/2026-02-15-misunderstandings_about_JS.md
+++ b/_posts/2026-02-15-misunderstandings_about_JS.md
@@ -1,6 +1,5 @@
 ---
 title: 자바스크립트에 대한 오해들
-date: 2026-02-15
 categories: [Front, JS]
 tags: [Front, JS]
 ---

--- a/_posts/sample
+++ b/_posts/sample
@@ -1,6 +1,5 @@
 ---
 title: What is different between Vue2 and Vue3?
-date: 2023-03
 categories: [Front, Vue]
 tags: [Front, Vue]
 ---


### PR DESCRIPTION
## Summary
- remove `date:` front matter from all files in `_posts`
- rely on Jekyll's filename-derived post date for published metadata

## Verification
- `bundle exec jekyll build`
- confirmed generated post HTML still shows the published date from the filename
- confirmed no remaining `date:` front matter lines under `_posts`